### PR TITLE
Use expected status code during creating notification rule

### DIFF
--- a/src/main/java/org/proshin/finapi/notificationrule/FpNotificationRules.java
+++ b/src/main/java/org/proshin/finapi/notificationrule/FpNotificationRules.java
@@ -72,7 +72,7 @@ public final class FpNotificationRules implements NotificationRules {
             this.endpoint,
             this.token,
             new JSONObject(
-                this.endpoint.post(this.url, this.token, parameters)
+                this.endpoint.post(this.url, this.token, parameters, 201)
             ),
             this.url
         );


### PR DESCRIPTION
Due to [documentation](https://sandbox.finapi.io/#!/Notification_Rules/createNotificationRule), in case of created record response code is:
```
201 Created notification rule
```