### PR TITLE
#241: create FinapiAuthenticationException

### DIFF
--- a/src/main/java/org/proshin/finapi/endpoint/FpEndpoint.java
+++ b/src/main/java/org/proshin/finapi/endpoint/FpEndpoint.java
@@ -43,6 +43,7 @@ import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.proshin.finapi.Jsonable;
 import org.proshin.finapi.accesstoken.AccessToken;
+import org.proshin.finapi.exception.FinapiAuthenticationException;
 import org.proshin.finapi.exception.FinapiException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,19 +72,8 @@ public final class FpEndpoint implements Endpoint {
             builder.setParameters(new ListOf<>(parameters));
             final HttpUriRequest get = new HttpGet(builder.build());
             get.addHeader(new AuthorizationHeader(token.accessToken()));
-            final HttpResponse response = this.client.execute(get);
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                throw new FinapiException(HttpStatus.SC_OK, response);
-            }
-            final String responseBody = new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-            LOGGER.info("Response body was: {}", responseBody);
-            return responseBody;
-        } catch (final IOException | URISyntaxException e) {
+            return this.execute(get);
+        } catch (final URISyntaxException e) {
             throw new RuntimeException(
                 new UncheckedText(
                     new FormattedText(
@@ -103,19 +93,8 @@ public final class FpEndpoint implements Endpoint {
             builder.setParameters(new ListOf<>(parameters));
             final HttpUriRequest delete = new HttpDelete(builder.build());
             delete.addHeader(new AuthorizationHeader(token.accessToken()));
-            final HttpResponse response = this.client.execute(delete);
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                throw new FinapiException(HttpStatus.SC_OK, response);
-            }
-            final String responseBody = new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-            LOGGER.info("Response body was: {}", responseBody);
-            return responseBody;
-        } catch (final IOException | URISyntaxException e) {
+            return this.execute(delete);
+        } catch (final URISyntaxException e) {
             throw new IllegalStateException(
                 new UncheckedText(
                     new FormattedText(
@@ -142,29 +121,9 @@ public final class FpEndpoint implements Endpoint {
      */
     @Override
     public String post(final String path, final HttpEntity entity, final int expected) {
-        try {
-            final HttpPost post = new HttpPost(this.endpoint + path);
-            post.setEntity(entity);
-            final HttpResponse response = this.client.execute(post);
-            if (response.getStatusLine().getStatusCode() != expected) {
-                throw new FinapiException(expected, response);
-            }
-            return new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-        } catch (final IOException e) {
-            throw new IllegalStateException(
-                new UncheckedText(
-                    new FormattedText(
-                        "Couldn't post to '%s'",
-                        path
-                    )
-                ).asString()
-            );
-        }
+        final HttpPost post = new HttpPost(this.endpoint + path);
+        post.setEntity(entity);
+        return this.execute(post, expected);
     }
 
     @Override
@@ -176,85 +135,25 @@ public final class FpEndpoint implements Endpoint {
 
     @Override
     public String post(final String path, final AccessToken token, final int expected) {
-        try {
-            final HttpUriRequest post = new HttpPost(this.endpoint + path);
-            post.addHeader(new AuthorizationHeader(token.accessToken()));
-            final HttpResponse response = this.client.execute(post);
-            if (response.getStatusLine().getStatusCode() != expected) {
-                throw new FinapiException(expected, response);
-            }
-            return new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-        } catch (final IOException e) {
-            throw new IllegalStateException(
-                new UncheckedText(
-                    new FormattedText(
-                        "Couldn't post to '%s'",
-                        path
-                    )
-                ).asString()
-            );
-        }
+        final HttpUriRequest post = new HttpPost(this.endpoint + path);
+        post.addHeader(new AuthorizationHeader(token.accessToken()));
+        return this.execute(post, expected);
     }
 
     @Override
     public String post(final String path, final AccessToken token, final HttpEntity entity, final int expected) {
-        try {
-            final HttpPost post = new HttpPost(this.endpoint + path);
-            post.addHeader(new AuthorizationHeader(token.accessToken()));
-            post.setEntity(entity);
-            final HttpResponse response = this.client.execute(post);
-            if (response.getStatusLine().getStatusCode() != expected) {
-                throw new FinapiException(expected, response);
-            }
-            return new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-        } catch (final IOException e) {
-            throw new IllegalStateException(
-                new UncheckedText(
-                    new FormattedText(
-                        "Couldn't post to '%s'",
-                        path
-                    )
-                ).asString()
-            );
-        }
+        final HttpPost post = new HttpPost(this.endpoint + path);
+        post.addHeader(new AuthorizationHeader(token.accessToken()));
+        post.setEntity(entity);
+        return this.execute(post, expected);
     }
 
     @Override
     public String patch(final String path, final AccessToken token, final HttpEntity entity, final int expected) {
-        try {
-            final HttpPatch patch = new HttpPatch(this.endpoint + path);
-            patch.addHeader(new AuthorizationHeader(token.accessToken()));
-            patch.setEntity(entity);
-            final HttpResponse response = this.client.execute(patch);
-            if (response.getStatusLine().getStatusCode() != expected) {
-                throw new FinapiException(expected, response);
-            }
-            return new UncheckedText(
-                new TextOf(
-                    new InputOf(response.getEntity().getContent()),
-                    StandardCharsets.UTF_8
-                )
-            ).asString();
-        } catch (final IOException e) {
-            throw new IllegalStateException(
-                new UncheckedText(
-                    new FormattedText(
-                        "Couldn't post to '%s'",
-                        path
-                    )
-                ).asString()
-            );
-        }
+        final HttpPatch patch = new HttpPatch(this.endpoint + path);
+        patch.addHeader(new AuthorizationHeader(token.accessToken()));
+        patch.setEntity(entity);
+        return this.execute(patch, expected);
     }
 
     @Override
@@ -267,6 +166,38 @@ public final class FpEndpoint implements Endpoint {
             ),
             HttpStatus.SC_OK
         );
+    }
+
+    private String execute(final HttpUriRequest request) {
+        return this.execute(request, HttpStatus.SC_OK);
+    }
+
+    private String execute(final HttpUriRequest request, final int expected) {
+        try {
+            final HttpResponse response = this.client.execute(request);
+            final int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
+                throw new FinapiAuthenticationException(response);
+            } else if (statusCode != expected) {
+                throw new FinapiException(expected, response);
+            }
+            return new UncheckedText(
+                new TextOf(
+                    new InputOf(response.getEntity().getContent()),
+                    StandardCharsets.UTF_8
+                )
+            ).asString();
+        } catch (final IOException e) {
+            throw new RuntimeException(
+                new UncheckedText(
+                    new FormattedText(
+                        "Couldn't get '%s'",
+                        request.getURI()
+                    )
+                ).asString(),
+                e
+            );
+        }
     }
 
     @SuppressWarnings("staticfree")

--- a/src/main/java/org/proshin/finapi/exception/FinapiAuthenticationException.java
+++ b/src/main/java/org/proshin/finapi/exception/FinapiAuthenticationException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Roman Proshin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.proshin.finapi.exception;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import org.apache.http.HttpResponse;
+import org.cactoos.io.InputOf;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
+import org.json.JSONObject;
+
+public final class FinapiAuthenticationException extends RuntimeException {
+
+    @SuppressWarnings("staticfree")
+    private static final long serialVersionUID = -2536176269994901299L;
+
+    @SuppressWarnings("TransientFieldNotInitialized")
+    private final transient String requestId;
+
+    @SuppressWarnings("nullfree")
+    public FinapiAuthenticationException(final HttpResponse response) {
+        this(
+            ((Supplier<String>) () -> {
+                try {
+                    final JSONObject jsonObject = new JSONObject(
+                        new UncheckedText(
+                            new TextOf(
+                                new InputOf(response.getEntity().getContent()),
+                                StandardCharsets.UTF_8
+                            )
+                        ).asString()
+                    );
+                    return String.format("%s: %s",
+                        jsonObject.getString("error"), jsonObject.getString("error_description")
+                    );
+                } catch (final IOException e) {
+                    throw new RuntimeException("Couldn't read the response body", e);
+                }
+            }
+            ).get(),
+            response.getFirstHeader("X-Request-Id").getValue()
+        );
+    }
+
+    public FinapiAuthenticationException(final String message, final String requestId) {
+        super(message);
+        this.requestId = requestId;
+    }
+
+    public String requestId() {
+        return this.requestId;
+    }
+}

--- a/src/main/java/org/proshin/finapi/exception/FinapiException.java
+++ b/src/main/java/org/proshin/finapi/exception/FinapiException.java
@@ -36,6 +36,8 @@ public final class FinapiException extends RuntimeException {
 
     @SuppressWarnings("TransientFieldNotInitialized")
     private final transient JSONObject origin;
+    @SuppressWarnings("TransientFieldNotInitialized")
+    private final transient String requestId;
     @SuppressWarnings({"TransientFieldNotInitialized", "OptionalUsedAsFieldOrParameterType"})
     private final transient Optional<String> location;
 
@@ -61,15 +63,22 @@ public final class FinapiException extends RuntimeException {
                 }
             }
             ).get(),
+            response.getFirstHeader("X-Request-Id").getValue(),
             Optional.ofNullable(response.getFirstHeader("Location"))
                 .map(NameValuePair::getValue)
                 .orElse(null)
         );
     }
 
-    public FinapiException(final String message, final JSONObject origin, final String location) {
+    public FinapiException(
+        final String message,
+        final JSONObject origin,
+        final String requestId,
+        final String location) {
+
         super(message);
         this.origin = origin;
+        this.requestId = requestId;
         this.location = Optional.ofNullable(location);
     }
 
@@ -85,7 +94,7 @@ public final class FinapiException extends RuntimeException {
     }
 
     public String requestId() {
-        return this.origin.getString("requestId");
+        return this.requestId;
     }
 
     public String endpoint() {

--- a/src/test/java/org/proshin/finapi/endpoint/FpEndpointTest.java
+++ b/src/test/java/org/proshin/finapi/endpoint/FpEndpointTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Roman Proshin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.proshin.finapi.endpoint;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import static org.assertj.core.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.JsonBody;
+import org.proshin.finapi.TestWithMockedEndpoint;
+import org.proshin.finapi.exception.FinapiAuthenticationException;
+
+final class FpEndpointTest extends TestWithMockedEndpoint {
+
+    @Test
+    void testAuthenticationException() {
+        final String body = '{' +
+            "  \"bankId\": 277672," +
+            '}';
+        this.server()
+            .when(
+                HttpRequest.request("/api/v1/bankConnections")
+                    .withMethod("POST")
+                    .withBody(new JsonBody(body))
+            ).respond(
+            HttpResponse.response('{' +
+                "  \"error\": \"unauthorized\"," +
+                "  \"error_description\": \"An Authentication object was not found in the SecurityContext\"" +
+                '}')
+                .withStatusCode(HttpStatus.SC_UNAUTHORIZED)
+                .withHeader("x-request-id", "request-id")
+        );
+
+        try {
+            this.endpoint()
+                .post(
+                    "/api/v1/bankConnections",
+                    new StringEntity(body, ContentType.APPLICATION_JSON),
+                    HttpStatus.SC_CREATED
+                );
+        } catch (final FinapiAuthenticationException e) {
+            // do nothing
+            return;
+        }
+        fail("Should never be reached");
+    }
+}

--- a/src/test/java/org/proshin/finapi/exception/FinapiExceptionTest.java
+++ b/src/test/java/org/proshin/finapi/exception/FinapiExceptionTest.java
@@ -62,6 +62,7 @@ public final class FinapiExceptionTest {
                 "  \"authContext\": \"1/2\"," +
                 "  \"bank\": \"00000000\"" +
                 '}'),
+            "request-id-01234567890123456789",
             "fake location"
         );
         assertThat(exception.getMessage()).isEqualTo("Test error message");


### PR DESCRIPTION
Will close https://github.com/proshin-roman/finapi-java-client/issues/241

I added a new exception `FinapiAuthenticationException` that is thrown whenever finAPI responds with 401 (unauthorized or invalid token). This way, each consumer can decide on how to deal with the situation.


Validated against sandbox.finapi.io v1.115 using

```
    @Test
    void testExpiredToken() {
        final FpEndpoint endpoint = new FpEndpoint("https://sandbox.finapi.io/");
        final FpAccessTokens tokens = new FpAccessTokens(endpoint);
        final AccessToken clientToken = tokens.clientToken("clientId", "clientSecret");
        final AccessToken userToken =
            tokens.userToken("clientId", "clientSecret", "username", "password");
        final FpBankConnections conn = new FpBankConnections(endpoint, userToken);
        // test token is valid
        final Iterable<BankConnection> query = conn.query(Arrays.asList(1L, 2L));
        assertThat(query).isEmpty();

        // invalidate the token
        tokens.revoke(clientToken, userToken, AccessTokens.RevokeToken.ACCESS_TOKEN_ONLY);

        try {
            // request should fail with FinapiAuthenticationException
            conn.query(Arrays.asList(1L, 2L));
        } catch (final Exception e) {
            if (e instanceof FinapiAuthenticationException) {
                // deal with expired token
            }
            final FinapiException cause = (FinapiException) e.getCause();
            for (final FinapiError error : cause.errors()) {
                System.out.println(error);
            }
        }
    }
```